### PR TITLE
Melhoado o README e o CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 Neste repo estão algumas brincadeiras nas horas vagas.
 
-1 - (loginAnimado) Tela de login contendo algumas animações usando animate do CSS e JavaScript.
-    * [O formulário vai aparecer vindo do fundo]
-    * [Os elementos do formulário aparecem da esquerda para a direita]
-        -> Para mudar o tempo de duração destas animações basta alterar a propriedade "animation-duration"
-    * [Ao clicar em login o formulário desce até sumir da tela]
-    * [Ao clicar em login com os campos em branco o formulário vai tremer]
-    * [Algumas formas ficam passando pela tela em diversas direções]
+# Diversos
 
-    Qualquer contribuição será bem-vinda, Deixar aqui meus agradecimentos ao trabalho do Mayk Brito, valeu.
+## Login animado
+
+1. Tela de `login` contendo algumas animações usando `animate` do CSS e JavaScript
+   * O formulário vai aparecer vindo do fundo
+   * Os elementos do formulário aparecem da esquerda para a direita
+     * Para mudar o tempo de duração destas animações basta alterar a propriedade `animation-duration`
+   * Ao clicar em `login` o formulário desce até sumir da tela
+   * Ao clicar em `login` com os campos em branco o formulário vai tremer
+   * Algumas formas ficam passando pela tela em diversas direções
+
+Qualquer contribuição será bem-vinda, eeixar aqui meus agradecimentos ao trabalho do Mayk Brito, valeu.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Neste repo estão algumas brincadeiras nas horas vagas.
 
 ## Login animado
 
-1. Tela de `login` contendo algumas animações usando `animate` do CSS e JavaScript
+1. Tela de *login* contendo algumas animações usando `animate` do CSS e JavaScript
    * O formulário vai aparecer vindo do fundo
    * Os elementos do formulário aparecem da esquerda para a direita
      * Para mudar o tempo de duração destas animações basta alterar a propriedade `animation-duration`
-   * Ao clicar em `login` o formulário desce até sumir da tela
-   * Ao clicar em `login` com os campos em branco o formulário vai tremer
+   * Ao clicar em *login* o formulário desce até sumir da tela
+   * Ao clicar em *login* com os campos em branco o formulário vai tremer
    * Algumas formas ficam passando pela tela em diversas direções
 
 Qualquer contribuição será bem-vinda, eeixar aqui meus agradecimentos ao trabalho do Mayk Brito, valeu.

--- a/loginAnimado/css/style.css
+++ b/loginAnimado/css/style.css
@@ -1,33 +1,39 @@
-/* Configuracoes gerais e resets do navegador */
-*{
+/* Configurações gerais e resets do navegador */
+
+* {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
 }
-body,html{
+
+body,
+html {
     height: 100vh;
     overflow: hidden;
 }
-body{
+
+body {
     background-color: #7159c1;
-    font-family: Roboto, Arial, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
-/* Estilizacao geral da pagina*/
-section{
+
+/* Estilização geral da página */
+
+section {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
 }
 
-h1{
+h1 {
     font-size: 32px;
     letter-spacing: 1px;
     margin: 10px 0;
     color: white;
 }
 
-form{
+form {
     margin: 20px 0;
     background-color: white;
     padding: 30px 25px;
@@ -35,11 +41,11 @@ form{
     overflow: hidden;
 }
 
-form .input-block{
+form .input-block {
     margin-bottom: 20px;
 }
 
-form .input-block label{
+form .input-block label {
     font-size: 14px;
     color: darkslateblue;
 }
@@ -54,9 +60,9 @@ form .input-block input {
     border-radius: 2px;
     border: 1px solid #ccddef;
     outline-color: #7159c1;
-  }
-  
-  form .btn-login {
+}
+
+form .btn-login {
     display: block;
     min-width: 120px;
     border: none;
@@ -65,128 +71,141 @@ form .input-block input {
     border-radius: 25px;
     margin: auto;
     padding: 7px;
-  }
+}
 
-/* Animacoes do frame */
+/* Animações do frame */
 
-form{
+form {
     animation-name: fade;
     animation-duration: 300ms;
 
 }
 
-form .input-block:nth-child(1){
+form .input-block:nth-child(1) {
     animation-name: inputs;
     animation-duration: 500ms;
 }
-form .input-block:nth-child(2){
+
+form .input-block:nth-child(2) {
     animation-name: inputs;
     animation-duration: 700ms;
     animation-delay: 100ms;
 }
-form .btn-login{
+
+form .btn-login {
     animation-name: inputs;
     animation-duration: 1s;
     animation-delay: 170ms;
 }
-form .input-block, form .btn-login{
+
+form .input-block,
+form .btn-login {
     animation-fill-mode: backwards;
 }
-/* Como o formulario de login deve aparecer*/
-@keyframes fade{
-    from{
+
+/* Como o formulário de login deve aparecer */
+
+@keyframes fade {
+    from {
         opacity: 0;
         transform: scale(0.1);
     }
-    to{
+
+    to {
         opacity: 1;
         transform: scale(1);
     }
 }
-/* Como os campos devem surginr */
-@keyframes inputs{
-    from{
+
+/* Como os campos devem surgir */
+
+@keyframes inputs {
+    from {
         opacity: 0;
         transform: translate(-30%, -50%);
     }
-    to{
+
+    to {
         opacity: 1;
-        transform: translate(0,0);
+        transform: translate(0, 0);
     }
 }
 
-/* Ao clicar no botao submit o formulário vai sumir */
-.form-hide{
+/* Ao clicar no botão de submissão, o formulário vai sumir */
+
+.form-hide {
     animation-name: formHide;
     animation-duration: 1s;
     animation-timing-function: ease-out;
-    animation-fill-mode: forwards ;
+    animation-fill-mode: forwards;
 }
-@keyframes formHide{
-    0%{
+
+@keyframes formHide {
+    0% {
         opacity: 0;
         transform: translateY(0);
 
     }
-    90%{
+
+    90% {
         opacity: 0.8;
     }
-    100%{
+
+    100% {
         opacity: 1;
         transform: translateY(100vh);
     }
 }
 
-/* treme o formulario*/
-.validate-error{
+/* Treme o formulário*/
+
+.validate-error {
     animation: treme 500ms linear, fade paused;
     animation-iteration-count: 2;
-    
-   /* animation-duration: 500ms;*/
-
-    
-    
+    /* animation-duration: 500ms;*/
 }
 
-@keyframes treme{
-    0%{
+@keyframes treme {
+    0% {
         transform: translateX(0);
-  
     }
-    40%{
-        transform: translateX(-20%);
 
-        
+    40% {
+        transform: translateX(-20%);
     }
-    80%{
+
+    80% {
         transform: translateX(20%);
 
     }
-    100%{
-        transform: translateX(0);
 
-        
+    100% {
+        transform: translateX(0);
     }
 }
 
 /* Quadrados */
-.quadrados li{
+
+.quadrados li {
     background-color: rgba(230, 230, 230, 0.15);
     display: block;
     position: absolute;
     bottom: -40px;
     animation: up 2s infinite alternate;
-    z-index:-1
+    z-index: -1
 }
-@keyframes up{
-    from{
+
+@keyframes up {
+    from {
         opacity: 0;
         transform: translateY(0);
     }
-    50%{
+
+    50% {
         opacity: 1;
     }
-    to{
+
+    to {
         transform: translateY(-700px) rotate(960deg);
     }
 }


### PR DESCRIPTION
Olá @bruno-salmito 

* README:
  * Reorganizei a lista, seguindo as regras do Markdown
  * As classes, os identificadores, os seletores e as propriedades devem ter ` `código` ` entre eles.
  * As palavras estrangeiras devem ser italizadas.

* `style.css`:
   * Formatado.
   * Retornei os acentos. Tu podes escrever os acentos nos comentários sem problemas no CSS e no HTML.
   * Nunca junte a classe, a vírgula e os parênteses, pois, seria ilegível, por exemplo:

Incorrecto:

```css
body,html{
}
```

Correcto:

```css
body, html {
}
```